### PR TITLE
プレイヤーのターンフローを管理するスクリプトを実装した

### DIFF
--- a/SwichChannelTag/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/SwichChannelTag/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -46,6 +46,8 @@ MonoBehaviour:
   - InitProcess
   - UpdateTargetPos
   - Change
+  - SetTurnFinished
+  - StartTurn
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow.meta
+++ b/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 17019748ef9be7a498bce3729a11f295
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow/PlayerTurnFlow.cs
+++ b/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow/PlayerTurnFlow.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using UnityEngine;
+using Photon.Realtime;
+using Photon.Pun;
+
+
+
+public class PlayerTurnFlow : MonoBehaviour
+{
+    GameFlowStateTypeBase _current;
+    PlayerState _currentState;
+
+    public EPlayerState PlayerState { get => _currentState.State; }
+
+    bool _isTurnFinished = false;
+    public bool IsTurnFinished
+    {
+        get => _isTurnFinished;
+        private set { SetTurnFinished(value); }
+    }
+
+    private void Start()
+    {
+        Player mine = PlayersManager.MinePlayerPhotonPlayer;
+
+        if (!mine.IsLocal) return;//プレイ者以外はこの処理を行わない
+
+        StartCoroutine(GameFlow());
+    }
+
+    IEnumerator GameFlow()
+    {
+        //この時点では他のコンポーネントの初期化が終わってない可能性があるため、一旦1フレーム待つ
+        yield return null;
+
+        //開始演出のステート(実装予定)
+
+
+        //
+
+
+        //終了演出のステート(実装予定)
+    }
+
+    IEnumerator CurrentStateUpdate()//現在のステートの更新処理
+    {
+        if (_current != null) yield break;
+
+        while (!_current.Finished)
+        {
+            yield return null;
+            _current.OnUpdate();
+        }
+    }
+
+    void ChangeState(GameFlowStateTypeBase nextState)//ステートの変更
+    {
+        if (_current != null) _current.OnExit();
+
+        _current = nextState;
+
+        if (_current != null) _current.OnEnter();
+    }
+
+    [PunRPC]
+    void SetTurnFinished(bool value)
+        => IsTurnFinished = value;
+}

--- a/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow/PlayerTurnFlow.cs
+++ b/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow/PlayerTurnFlow.cs
@@ -9,6 +9,7 @@ public class PlayerTurnFlow : MonoBehaviour
 {
     GameFlowStateTypeBase _current;
     PlayerState _currentState;
+    bool _isLocal;
 
     public EPlayerState PlayerState { get => _currentState.State; }
 
@@ -22,8 +23,9 @@ public class PlayerTurnFlow : MonoBehaviour
     private void Start()
     {
         Player mine = PlayersManager.MinePlayerPhotonPlayer;
+        _isLocal = mine.IsLocal;
 
-        if (!mine.IsLocal) return;//プレイ者以外はこの処理を行わない
+        if (!_isLocal) return;//ローカル以外はこの処理を行わない
 
         StartCoroutine(GameFlow());
     }
@@ -33,13 +35,13 @@ public class PlayerTurnFlow : MonoBehaviour
         //この時点では他のコンポーネントの初期化が終わってない可能性があるため、一旦1フレーム待つ
         yield return null;
 
-        //開始演出のステート(実装予定)
+        //開始演出のステート
 
 
         //
 
 
-        //終了演出のステート(実装予定)
+        //終了演出のステート
     }
 
     IEnumerator CurrentStateUpdate()//現在のステートの更新処理
@@ -65,4 +67,19 @@ public class PlayerTurnFlow : MonoBehaviour
     [PunRPC]
     void SetTurnFinished(bool value)
         => IsTurnFinished = value;
+
+    [PunRPC]
+    public void StartTurn(EPlayerState turnSide)
+    {
+        if(!_isLocal) return;
+
+        if(PlayerState == turnSide)
+        {
+            ChangeState(null);
+        }
+        else
+        {
+            IsTurnFinished = false;
+        }
+    }
 }

--- a/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow/PlayerTurnFlow.cs.meta
+++ b/SwichChannelTag/Assets/Scripts/Components/PlayerTurnFlow/PlayerTurnFlow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca2e455730237b5408c3297d9200b3e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
GameFlowManager.csにプレイヤーターン特有の変数周りを追加したもの
ゲームフローのターンの遷移については[miro](https://miro.com/app/board/uXjVIGwkZmI=/?moveToWidget=3458764641301783114&cot=14)を参照してください